### PR TITLE
Updated config to include Content-Security-Policy

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -39,6 +39,15 @@ http {
   # this particular website if it was disabled by the user.
   # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
   add_header X-XSS-Protection "1; mode=block";
+
+  # with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
+  # you can tell the browser that it can only download content from the domains you explicitly allow
+  # http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+  # https://www.owasp.org/index.php/Content_Security_Policy
+  # I need to change our application code so we can increase security by disabling 'unsafe-inline' 'unsafe-eval'
+  # directives for css and js(if you have inline css or js, you will need to keep it too).
+  # more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
+  add_header Content-Security-Policy upgrade-insecure-requests;
   # ---------------------------------------------------------------------------
 
   # Avoid situations where a hostname is too long when dealing with vhosts.


### PR DESCRIPTION
According to the documentation at
https://developers.google.com/web/fundamentals/security/csp, the
Content-Security-Policy header set to upgrade-insecure-requests
instructs all user agents to rewrite URLs from HTTP to HTTPS. Further,
this is recommended as a best practice by IBM